### PR TITLE
feat: add support for custom binary via ANYCABLE_THRUSTER_BIN_PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 
 # Ignore Gem packaging artifacts
 /pkg
-/exe/
+/exe/*
 !/exe/thrust

--- a/README.md
+++ b/README.md
@@ -26,6 +26,40 @@ ANYCABLE_DEBUG=true thrust bin/rails s
 ANYCABLE_OPT="-debug" thrust bin/rails s
 ```
 
+## Using a custom AnyCable binary
+
+AnyCable Thruster can launch an external AnyCable-compatible binary (e.g., **AnyCable Pro**) instead of the one bundled with the gem.
+Set `ANYCABLE_THRUSTER_BIN_PATH` to either a **full path** or a **command name** (looked up in `$PATH`).  
+If the variable is not set, Thruster falls back to the bundled per-platform binary.
+
+### Local usage
+
+If you have `anycable-thruster` available in your `$PATH`:
+
+```sh
+# Thruster will exec the given binary and pass through all CLI args
+ANYCABLE_THRUSTER_BIN_PATH=anycable-thruster thrust bin/rails server
+
+#You may also use an absolute path if you prefer:
+ANYCABLE_THRUSTER_BIN_PATH=/usr/local/bin/anycable-thruster thrust bin/rails server
+```
+
+### Heroku (with the AnyCable Go buildpack)
+
+**Configure the AnyCable Go buildpack to fetch the Thruster binary:**
+- `HEROKU_ANYCABLE_GO_BINARY_NAME=anycable-thruster`
+
+In Procfile:
+
+```
+# resolves via PATH
+web: ANYCABLE_THRUSTER_BIN_PATH=anycable-thruster thrust bin/rails server
+
+# resolve absolute path at runtime
+# web: ANYCABLE_THRUSTER_BIN_PATH=$(which anycable-thruster) thrust bin/rails server
+```
+
+For full buildpack options see the buildpack [README](https://github.com/anycable/heroku-anycable-go).
 ----
 
 > [!NOTE]

--- a/exe/thrust
+++ b/exe/thrust
@@ -1,11 +1,26 @@
 #! /usr/bin/env ruby
 
-PLATFORM = [ :cpu, :os ].map { |m| Gem::Platform.local.send(m) }.join("-")
+ENV_KEY = "ANYCABLE_THRUSTER_BIN_PATH"
+CUSTOM_ANYCABLE_PATH = ENV[ENV_KEY].to_s
+
+if CUSTOM_ANYCABLE_PATH != ""
+  begin
+    exec(CUSTOM_ANYCABLE_PATH, *ARGV)
+  rescue Errno::ENOENT
+    warn("ERROR: #{ENV_KEY}=#{CUSTOM_ANYCABLE_PATH.inspect} not found in PATH or as a file.")
+    exit 1
+  rescue SystemCallError => e
+    warn("ERROR: #{ENV_KEY}=#{CUSTOM_ANYCABLE_PATH.inspect} failed: #{e.class}: #{e.message}")
+    exit 1
+  end
+end
+
+PLATFORM = %i[cpu os].map { |m| Gem::Platform.local.send(m) }.join("-")
 EXECUTABLE = File.expand_path(File.join(__dir__, PLATFORM, "thrust"))
 
 if File.exist?(EXECUTABLE)
   exec(EXECUTABLE, *ARGV)
 else
-  STDERR.puts("ERROR: Unsupported platform: #{PLATFORM}")
+  warn("ERROR: Unsupported platform: #{PLATFORM}")
   exit 1
 end


### PR DESCRIPTION
### What is the purpose of this pull request?

To add a mechanism to execute a custom thrust binary via the `ANYCABLE_THRUSTER_BIN_PATH` environment variable. This is required for using pre-compiled Pro versions.

### What changes did you make?
- The exe/thrust script now checks for `ANYCABLE_THRUSTER_BIN_PATH` at startup.

- If the variable is set, the script immediately calls exec with its value.

  - It handles both full paths and command names found in the system's $PATH.
  
  - `Errno::ENOENT` and `SystemCallError` exceptions are caught to provide error feedback.

- If the variable is not set, the script maintains its original behavior of running the bundled binary.